### PR TITLE
Add focused Linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .venv*
+venv/
 __pycache__/
 *.pyc
 config/config_path.txt

--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ Get up and running in less than a minute!
 
 ---
 
+## 🐧 Linux From Source
+
+Linux support requires Discord Desktop with a working Rich Presence IPC socket and a GeForce NOW window or native-app log source. Avoid Snap Discord for Rich Presence; use the official deb/apt Discord, Flatpak Discord with RPC permissions, or Vesktop with RPC enabled.
+
+The app does not start Discord or GeForce NOW unless the matching tray setting is enabled. Start Discord manually before launching the presence app.
+
+Run from source with:
+
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install -r requirements.txt
+    PYTHONPATH=. python3 src/GeForceNOWRichPresence.py
+
+Run Linux diagnostics with:
+
+    PYTHONPATH=. python3 src/GeForceNOWRichPresence.py --diagnose
+
+For X11/XWayland window-title detection, install xdotool. On Wayland, the native GeForce NOW app is detected through CxNative_GeForceNOW.log; set GFN_LOG_PATH if that log lives in a custom location.
+
+---
+
 ## 🧠 How it Works
 
 The application runs quietly and efficiently in the background:

--- a/src/GeForceNOWRichPresence.py
+++ b/src/GeForceNOWRichPresence.py
@@ -147,8 +147,17 @@ def main():
     
     parser = argparse.ArgumentParser()
     parser.add_argument("--delay", type=int, default=0, help="Delay startup by N seconds")
+    parser.add_argument("--diagnose", action="store_true", help="Print Linux Discord/GFN diagnostics and exit")
     args, unknown = parser.parse_known_args()
     
+    if args.diagnose:
+        if sys.platform.startswith("linux"):
+            from src.core.linux_diagnostics import build_diagnostics
+            print(build_diagnostics())
+        else:
+            print("Diagnostics are currently only available on Linux.")
+        return
+
     if args.delay > 0:
         logger.info(f"Esperando {args.delay} segundos antes de iniciar...")
         time.sleep(args.delay)

--- a/src/core/linux_diagnostics.py
+++ b/src/core/linux_diagnostics.py
@@ -1,0 +1,125 @@
+import glob
+import os
+import socket
+from pathlib import Path
+
+import psutil
+
+from src.core.linux_gfn_log import find_native_log_path, game_from_native_log as _game_from_native_log
+from src.core.linux_window_detector import LinuxWindowDetector
+from src.core.utils import CONFIG_DIR, safe_json_load
+
+
+def _runtime_dir() -> Path:
+    return Path(os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}")
+
+
+def _socket_connects(path: str) -> bool:
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(1)
+            client.connect(path)
+        return True
+    except Exception:
+        return False
+
+
+def discord_ipc_paths() -> list[tuple[str, bool]]:
+    base = _runtime_dir()
+    candidates = []
+    for subdir in (".", "snap.discord", "app/com.discordapp.Discord", "app/com.discordapp.DiscordCanary"):
+        candidates.extend(glob.glob(str(base / subdir / "discord-ipc-*")))
+    seen = set()
+    result = []
+    for path in candidates:
+        if path in seen:
+            continue
+        seen.add(path)
+        result.append((path, _socket_connects(path)))
+    return result
+
+
+def discord_package_type() -> str:
+    found_discord = False
+    try:
+        for proc in psutil.process_iter(attrs=["name", "exe", "cmdline"]):
+            name = (proc.info.get("name") or "").lower()
+            exe = proc.info.get("exe") or ""
+            cmdline = " ".join(proc.info.get("cmdline") or [])
+            combined = f"{exe} {cmdline}".lower()
+            if "discord" not in name and "discord" not in combined:
+                continue
+            found_discord = True
+            if "/snap/discord/" in combined:
+                return "snap"
+            if "flatpak" in combined or "/app/" in combined or "com.discordapp.discord" in combined:
+                return "flatpak"
+            if "/usr/share/discord" in combined or "/opt/discord" in combined or "/usr/bin/discord" in combined or "/.config/discord/" in combined:
+                return "deb/apt"
+    except Exception:
+        pass
+    return "unknown-running" if found_discord else "not-running"
+
+
+def gfn_processes() -> list[str]:
+    matches = []
+    try:
+        for proc in psutil.process_iter(attrs=["name", "cmdline"]):
+            name = proc.info.get("name") or ""
+            cmdline = " ".join(proc.info.get("cmdline") or [])
+            combined = f"{name} {cmdline}".lower()
+            if "geforcenow" in combined or "geforce now" in combined or "play.geforcenow.com" in combined:
+                matches.append(f"{proc.pid}: {name} {cmdline}".strip())
+    except Exception:
+        pass
+    return matches[:8]
+
+
+def gfn_native_log_path():
+    return find_native_log_path()
+
+
+def game_from_native_log():
+    games = safe_json_load(CONFIG_DIR / "games_config_merged.json") or {}
+    game, path = _game_from_native_log(games)
+    return game, str(path) if path else None
+
+
+def build_diagnostics() -> str:
+    lines = ["GeForce NOW Rich Presence Linux diagnostics"]
+    lines.append(f"Session type: {os.environ.get('XDG_SESSION_TYPE', 'unknown')}")
+    lines.append(f"Desktop: {os.environ.get('XDG_CURRENT_DESKTOP', 'unknown')}")
+    lines.append(f"Runtime dir: {_runtime_dir()}")
+
+    package = discord_package_type()
+    lines.append(f"Discord package: {package}")
+    ipc_paths = discord_ipc_paths()
+    if ipc_paths:
+        for path, ok in ipc_paths:
+            lines.append(f"Discord IPC: {path} ({'connects' if ok else 'not connectable'})")
+    else:
+        lines.append("Discord IPC: not found")
+    if package == "snap":
+        lines.append("Warning: Snap Discord often does not expose Rich Presence IPC to normal apps.")
+
+    detector = LinuxWindowDetector()
+    raw_title = detector.get_gfn_window_title()
+    game_from_title = detector.extract_game_name(raw_title) if raw_title else None
+    lines.append(f"Window detector: {detector.method or 'none'}")
+    lines.append(f"GFN window title: {raw_title or 'not found'}")
+    lines.append(f"Game from title: {game_from_title or 'not found'}")
+
+    processes = gfn_processes()
+    lines.append(f"GFN processes: {len(processes)} found")
+    for process in processes:
+        lines.append(f"  {process}")
+
+    log_game, log_path = game_from_native_log()
+    lines.append(f"Native GFN log: {log_path or 'not found'}")
+    lines.append(f"Game from native log: {log_game or 'not found'}")
+
+    final_game = game_from_title or log_game
+    source = "window title" if game_from_title else ("native log" if log_game else "none")
+    lines.append(f"Final detected game: {final_game or 'not found'}")
+    lines.append(f"Detection source: {source}")
+    return "\n".join(lines)

--- a/src/core/linux_gfn_log.py
+++ b/src/core/linux_gfn_log.py
@@ -1,0 +1,80 @@
+import os
+import re
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_NATIVE_LOG_PATHS = (
+    Path(".var/app/com.nvidia.geforcenow/.local/state/NVIDIA/GeForceNOW/CxNative_GeForceNOW.log"),
+    Path(".local/state/NVIDIA/GeForceNOW/CxNative_GeForceNOW.log"),
+    Path(".config/NVIDIA/GeForceNOW/CxNative_GeForceNOW.log"),
+)
+
+_STREAM_START_RE = re.compile(
+    r"^(?P<ts>\S+)\s+.*?onStreamStart.*?"
+    r"drsProfileName:(?P<name>.*?)\s+"
+    r"shortName:(?P<short>\S*)\s+"
+    r"cmsId:(?P<cms>\d+)",
+    re.MULTILINE,
+)
+_STREAM_STOP_RE = re.compile(
+    r"^(?P<ts>\S+)\s+.*?onStreamStop\s+processId:(?P<cms>\d+)",
+    re.MULTILINE,
+)
+
+
+def find_native_log_path(env_path: Optional[str] = None, home: Optional[Path] = None) -> Optional[Path]:
+    candidates = []
+    env_path = env_path if env_path is not None else os.getenv("GFN_LOG_PATH", "").strip()
+    if env_path:
+        candidates.append(Path(env_path).expanduser())
+
+    base_home = Path.home() if home is None else Path(home)
+    candidates.extend(base_home / relative for relative in DEFAULT_NATIVE_LOG_PATHS)
+
+    return next((path for path in candidates if path.exists()), None)
+
+
+def parse_native_log_text(text: str) -> tuple[Optional[str], Optional[str]]:
+    events = []
+    for match in _STREAM_START_RE.finditer(text):
+        events.append((match.start(), "start", match.group("cms"), match.group("name").strip()))
+    for match in _STREAM_STOP_RE.finditer(text):
+        events.append((match.start(), "stop", match.group("cms"), None))
+
+    active = {}
+    for _, kind, cms_id, name in sorted(events, key=lambda item: item[0]):
+        if kind == "start":
+            active[cms_id] = name
+        else:
+            active.pop(cms_id, None)
+
+    if not active:
+        return None, None
+    cms_id, name = next(reversed(active.items()))
+    return cms_id, name or None
+
+
+def game_name_for_cms_id(cms_id: str, games_map: Optional[dict]) -> Optional[str]:
+    if not cms_id or not games_map:
+        return None
+    cms_id = str(cms_id)
+    for key, info in games_map.items():
+        if str((info or {}).get("cmsId") or "") == cms_id:
+            return (info or {}).get("name") or key
+    return None
+
+
+def game_from_native_log(games_map: Optional[dict] = None, log_path: Optional[Path] = None) -> tuple[Optional[str], Optional[Path]]:
+    path = Path(log_path) if log_path else find_native_log_path()
+    if not path:
+        return None, None
+
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except Exception:
+        return None, path
+
+    cms_id, raw_name = parse_native_log_text(text)
+    if not cms_id:
+        return None, path
+    return game_name_for_cms_id(cms_id, games_map) or raw_name, path

--- a/src/core/linux_window_detector.py
+++ b/src/core/linux_window_detector.py
@@ -1,0 +1,117 @@
+"""Linux GeForce NOW window title detection."""
+
+import logging
+import re
+import shutil
+import subprocess
+from typing import Optional
+
+logger = logging.getLogger("geforce_presence")
+
+GFN_TITLE_PATTERNS = [
+    re.compile(r"^GeForce\s*NOW\s*[-–—]\s*(.+)", re.IGNORECASE),
+    re.compile(r"^(.+?)\s*[-–—]\s*GeForce\s*NOW\s*$", re.IGNORECASE),
+    re.compile(r"GeForce\s*NOW'(?:da|de|ta|te)\s+(.+)", re.IGNORECASE),
+    re.compile(r"(.+?)\s+(?:on|en|in|via)\s+GeForce\s*NOW\b", re.IGNORECASE),
+]
+
+GFN_LOBBY_PATTERNS = [
+    re.compile(r"^\s*GeForce\s*NOW\s*$", re.IGNORECASE),
+    re.compile(r"^\s*GeForce\s*NOW\s*[|]\s*Home\s*$", re.IGNORECASE),
+]
+
+BROWSER_PROCESS_NAMES = ("chrome", "chromium", "firefox", "edge", "brave", "vivaldi", "opera")
+
+
+class LinuxWindowDetector:
+    """Detect GeForce NOW game titles on Linux using xdotool when available."""
+
+    def __init__(self):
+        self._method = "xdotool" if shutil.which("xdotool") else None
+        if self._method:
+            logger.info("🐧 Linux window detection: xdotool will be used (X11/XWayland)")
+        else:
+            logger.warning("🐧 Linux window detection: xdotool not found. Native GFN logs will be used when available.")
+
+    @property
+    def method(self) -> Optional[str]:
+        return self._method
+
+    def get_gfn_window_title(self) -> Optional[str]:
+        if self._method != "xdotool":
+            return None
+
+        for query in ("GeForce NOW", "GeForceNOW", "play.geforcenow.com"):
+            title = self._title_from_xdotool_query(query)
+            if title:
+                return title
+        return None
+
+    def _title_from_xdotool_query(self, query: str) -> Optional[str]:
+        try:
+            result = subprocess.run(
+                ["xdotool", "search", "--name", query],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except Exception as e:
+            logger.debug(f"xdotool search failed for {query!r}: {e}")
+            return None
+
+        if result.returncode != 0 or not result.stdout.strip():
+            return None
+
+        for window_id in result.stdout.splitlines():
+            window_id = window_id.strip()
+            if not window_id:
+                continue
+            title = self._window_title(window_id)
+            if title and (self.extract_game_name(title) or self._is_gfn_lobby(title)):
+                return title
+        return None
+
+    def _window_title(self, window_id: str) -> Optional[str]:
+        try:
+            result = subprocess.run(
+                ["xdotool", "getwindowname", window_id],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+        except Exception:
+            return None
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip() or None
+
+    def extract_game_name(self, raw_title: str) -> Optional[str]:
+        if not raw_title or self._is_gfn_lobby(raw_title):
+            return None
+
+        for pattern in GFN_TITLE_PATTERNS:
+            match = pattern.search(raw_title)
+            if not match:
+                continue
+            game = match.group(1).strip()
+            if game and len(game) > 1 and game.lower() not in ("home", "games", "library"):
+                return game
+        return None
+
+    def _is_gfn_lobby(self, raw_title: str) -> bool:
+        return any(pattern.match(raw_title) for pattern in GFN_LOBBY_PATTERNS)
+
+    def is_gfn_running(self) -> bool:
+        try:
+            import psutil
+
+            for proc in psutil.process_iter(attrs=["name", "cmdline"]):
+                name = (proc.info.get("name") or "").lower()
+                cmdline = " ".join(proc.info.get("cmdline") or []).lower()
+                if "geforcenow" in name or "geforce now" in cmdline or "play.geforcenow.com" in cmdline:
+                    return True
+                if any(browser in name for browser in BROWSER_PROCESS_NAMES) and "geforce" in cmdline:
+                    return True
+        except Exception:
+            pass
+        return False

--- a/src/core/presence_manager.py
+++ b/src/core/presence_manager.py
@@ -24,6 +24,15 @@ from pypresence import Presence
 from src.core.utils import safe_json_load, save_json, CONFIG_DIR, BASE_DIR, DISCORD_CACHE_PATH, DISCORD_DETECTABLE_URL, DISCORD_CACHE_TTL, DISCORD_AUTO_APPLY_THRESHOLD, DISCORD_ASK_TIMEOUT, IS_WINDOWS, IS_MACOS, IS_LINUX, validate_discord_cache, download_from_github
 from src.core.steam_scraper import SteamScraper, find_steam_appid_by_name
 from src.core.cookie_manager import CookieManager
+from src.core.linux_gfn_log import game_from_native_log
+
+if IS_LINUX:
+    try:
+        from src.core.linux_window_detector import LinuxWindowDetector
+    except ImportError:
+        LinuxWindowDetector = None
+else:
+    LinuxWindowDetector = None
 
 # Import win32 libs inside methods or here if safe
 if IS_WINDOWS:
@@ -89,6 +98,12 @@ class PresenceManager(QObject):
 
         self._force_stop_time = 0
         self.current_game_start_time = None
+        self._linux_detector = None
+        if IS_LINUX and LinuxWindowDetector is not None:
+            try:
+                self._linux_detector = LinuxWindowDetector()
+            except Exception as e:
+                logger.warning(f"Linux window detector could not be started: {e}")
         
         self.cleanup_all_fake_processes() # Clean startup
 
@@ -380,8 +395,7 @@ class PresenceManager(QObject):
                 except Exception as e:
                     err_str = str(e)
                     if "Could not find Discord" in err_str or "Discord installed and running" in err_str:
-                        logger.error(f"💨 No se pudo conectar a Discord RPC tras varios intentos. Relanzando Discord...")
-                        AppLauncher.launch_discord()
+                        logger.error("Discord RPC socket not found. Start Discord manually if you want Rich Presence.")
                     else:
                         logger.error(f"❌ Error conectando a Discord RPC: {e}")
                     self.rpc = None
@@ -1140,6 +1154,12 @@ class PresenceManager(QObject):
         else:
              logger.info(f"ℹ️ Usuario ignoró match Discord para '{game_key}'")
 
+    def _find_linux_game_from_native_logs(self):
+        game, path = game_from_native_log(self.games_map)
+        if path and not game:
+            logger.debug(f"Linux GFN native log found but no active stream: {path}")
+        return game
+
     def check_presence(self):
         try:
             self.check_quests() # Check optional quests
@@ -1243,37 +1263,35 @@ class PresenceManager(QObject):
                                 logger.debug(f"Error leyendo logs para fallback en macOS: {log_err}")
 
             elif IS_LINUX:
-                # Linux logic using xprop (assumes X11 for now)
-                # We could also try /proc, but window title usually needs X11/Wayland tools
-                try:
-                    # Check if xprop is available
-                    # We are looking for a window with property _NET_WM_NAME or WM_NAME
-                    # and class name (WM_CLASS) related to GeForceNOW (if it exists)
-                    # For now, let's try a generic approach if the user is running it via browser/electron
-                    
-                    # Alternative: use standard 'w' tool or similar if available, but xprop is standard-ish for X11
-                    
-                    # We will try to find a window with "GeForce NOW" in title
-                    # cmd: xprop -root _NET_ACTIVE_WINDOW
-                    # then get title
-                    
-                    # Simple approach: Check all windows (requires tools)
-                    # Better: rely on process name first?
-                    # GFN on linux is likely Chrome/Edge.
-                    
-                    # NOTE: Since GFN is web-based on Linux usually, detection might be tricky without a dedicated app.
-                    # If this is for a dedicated Electron wrapper, we assume process name matches.
-                    
-                    pass 
-                except Exception:
-                    pass
-                
-                # Placeholder for Linux title detection
-                # If running via Browser, title might be "GeForce NOW - Google Chrome"
-                pass
-            
+                if self._linux_detector:
+                    try:
+                        raw_title = self._linux_detector.get_gfn_window_title()
+                        if raw_title:
+                            game_name = self._linux_detector.extract_game_name(raw_title)
+                            if game_name:
+                                title = raw_title
+                                setattr(self, "_linux_game_name", game_name)
+                            else:
+                                log_game = self._find_linux_game_from_native_logs()
+                                if log_game:
+                                    title = f"{log_game} on GeForce NOW"
+                                    setattr(self, "_linux_game_name", log_game)
+                                else:
+                                    setattr(self, "_linux_game_name", None)
+                                    self.log_once("⚠️ GeForce NOW is open but game has not started (lobby/home)")
+                                    return None
+                        else:
+                            log_game = self._find_linux_game_from_native_logs()
+                            if log_game:
+                                title = f"{log_game} on GeForce NOW"
+                                setattr(self, "_linux_game_name", log_game)
+                            else:
+                                setattr(self, "_linux_game_name", None)
+                    except Exception as e:
+                        logger.debug(f"Linux window detection error: {e}")
+
             if not title:
-                self.log_once("⚠️ GeForce NOW no está abierto (o sin ventana activa)")
+                self.log_once("⚠️ GeForce NOW is not open (or no active window)")
                 return None
 
             last_title = getattr(self, "_last_window_title", None)
@@ -1290,14 +1308,19 @@ class PresenceManager(QObject):
                     self.gfn_error_detected.emit()
                 return None
 
-            clean = re.sub(r'\s*(en|on|in|via)?\s*GeForce\s*NOW.*$', '', title, flags=re.IGNORECASE).strip()
-            clean = re.sub(r'[®™]', '', clean).strip()
+            if IS_LINUX:
+                clean = getattr(self, "_linux_game_name", None)
+                if not clean:
+                    return None
+            else:
+                clean = re.sub(r'\s*(en|on|in|via)?\s*GeForce\s*NOW.*$', '', title, flags=re.IGNORECASE).strip()
+                clean = re.sub(r'[®™]', '', clean).strip()
+                if not clean:
+                    return None
             
             last_clean = getattr(self, "_last_clean_title", None)
             if clean != last_clean:
                 setattr(self, "_last_clean_title", clean)
-            if not clean:
-                return None
 
             appid = None 
             for game_name, info in self.games_map.items():

--- a/src/ui/tray_icon.py
+++ b/src/ui/tray_icon.py
@@ -5,7 +5,7 @@ from PyQt5.QtWidgets import QSystemTrayIcon, QMenu, QAction, QApplication, QMess
 from PyQt5.QtGui import QIcon
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QDialog
-from src.core.utils import ASSETS_DIR, LOG_FILE, set_autostart_windows
+from src.core.utils import ASSETS_DIR, LOG_FILE, IS_LINUX, set_autostart_windows
 from src.core.app_launcher import AppLauncher
 from src.ui.dialogs import AskGameDialog, MatchSelectionDialog, GamingMessageBox, GamingInputDialog, QuestListDialog, CustomPresenceDialog, AboutDialog, GFNRepairDialog, GAMING_STYLESHEET
 from src.core.utils import get_lang_from_registry, load_locale
@@ -155,6 +155,11 @@ class SystemTrayIcon(QSystemTrayIcon):
         logs_action = QAction(TEXTS.get("tray_open_logs", "Open logs"), self.menu)
         logs_action.triggered.connect(self.open_logs)
         self.menu.addAction(logs_action)
+
+        if IS_LINUX:
+            diagnose_action = QAction("Linux Diagnostics", self.menu)
+            diagnose_action.triggered.connect(self.open_linux_diagnostics)
+            self.menu.addAction(diagnose_action)
 
         # About
         about_action = QAction(TEXTS.get("about", "About"), self.menu)
@@ -422,6 +427,14 @@ class SystemTrayIcon(QSystemTrayIcon):
     def open_about(self):
         dlg = AboutDialog()
         dlg.exec_()
+
+    def open_linux_diagnostics(self):
+        try:
+            from src.core.linux_diagnostics import build_diagnostics
+            GamingMessageBox.show_info(None, "Linux Diagnostics", build_diagnostics())
+        except Exception as e:
+            logger.error(f"Error running Linux diagnostics: {e}")
+            self.showMessage("Linux Diagnostics", str(e), QSystemTrayIcon.Warning, 5000)
 
     def open_custom_presence_dialog(self):
         game = self.pm.forced_game or self.pm.last_game

--- a/tests/test_linux_gfn_log.py
+++ b/tests/test_linux_gfn_log.py
@@ -1,0 +1,33 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.core.linux_gfn_log import game_from_native_log, parse_native_log_text
+
+
+START_ROCKET = "2026-05-31T11:49:56.467[I] GfnAppInfo.cpp:680  onStreamStart Inserted processInfo processId:100871611 name: type:0 parentProcessId:0 drsAppName:Rocket League® drsProfileName:Rocket League® shortName:rocket_league_egs cmsId:100871611 chromaName: isDistributor=0"
+STOP_ROCKET = "2026-05-31T11:53:01.459[I] GfnAppInfo.cpp:692  onStreamStop processId:100871611 erased from processMap"
+START_SUBNAUTICA = "2026-05-31T13:34:07.464[I] GfnAppInfo.cpp:680  onStreamStart Inserted processInfo processId:107647091 name: type:0 parentProcessId:0 drsAppName:Subnautica 2 drsProfileName:Subnautica 2 shortName:afba7bfc cmsId:107647091 chromaName: isDistributor=0"
+
+
+class LinuxGfnLogTests(unittest.TestCase):
+    def test_parse_active_stream(self):
+        self.assertEqual(parse_native_log_text(START_ROCKET), ("100871611", "Rocket League®"))
+
+    def test_parse_stopped_stream_returns_none(self):
+        self.assertEqual(parse_native_log_text(START_ROCKET + "\n" + STOP_ROCKET), (None, None))
+
+    def test_latest_active_stream_wins(self):
+        text = START_ROCKET + "\n" + START_SUBNAUTICA
+        self.assertEqual(parse_native_log_text(text), ("107647091", "Subnautica 2"))
+
+    def test_game_from_native_log_prefers_mapped_name(self):
+        games = {"Rocket League": {"cmsId": "100871611", "name": "Rocket League"}}
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "CxNative_GeForceNOW.log"
+            log_path.write_text(START_ROCKET, encoding="utf-8")
+            self.assertEqual(game_from_native_log(games, log_path), ("Rocket League", log_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_linux_window_detector.py
+++ b/tests/test_linux_window_detector.py
@@ -1,0 +1,21 @@
+import unittest
+
+from src.core.linux_window_detector import LinuxWindowDetector
+
+
+class LinuxWindowDetectorTests(unittest.TestCase):
+    def setUp(self):
+        self.detector = LinuxWindowDetector()
+
+    def test_extract_suffix_title(self):
+        self.assertEqual(self.detector.extract_game_name("Rocket League - GeForce NOW"), "Rocket League")
+
+    def test_extract_prefix_title(self):
+        self.assertEqual(self.detector.extract_game_name("GeForce NOW - Subnautica 2"), "Subnautica 2")
+
+    def test_lobby_title_has_no_game(self):
+        self.assertIsNone(self.detector.extract_game_name("GeForce NOW"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Linux GeForce NOW detection through xdotool window titles and native CxNative_GeForceNOW.log fallback
- add Linux diagnostics via --diagnose and tray menu entry
- avoid auto-launching Discord when RPC is unavailable
- document Linux source setup and Discord IPC notes
- add unit tests for Linux title extraction and native log parsing

## Testing
- venv/bin/python -m py_compile src/GeForceNOWRichPresence.py src/core/presence_manager.py src/core/linux_window_detector.py src/core/linux_diagnostics.py src/core/linux_gfn_log.py src/ui/tray_icon.py tests/test_linux_gfn_log.py tests/test_linux_window_detector.py
- PYTHONPATH=. venv/bin/python -m unittest discover -s tests
- PYTHONPATH=. venv/bin/python src/GeForceNOWRichPresence.py --diagnose